### PR TITLE
Check for private ChatWoot Message

### DIFF
--- a/chatwoot/WhatsApp___ChatWoot__ChatWoot____WAHA_Messages.json
+++ b/chatwoot/WhatsApp___ChatWoot__ChatWoot____WAHA_Messages.json
@@ -88,6 +88,16 @@
                 "operation": "equals",
                 "name": "filter.operator.equals"
               }
+            },
+            {
+              "id": "81d466b4-47e6-45f9-9979-3455ea217073",
+              "leftValue": "={{ $json.body.private }}",
+              "rightValue": "",
+              "operator": {
+                "type": "boolean",
+                "operation": "false",
+                "singleValue": true
+              }
             }
           ],
           "combinator": "and"


### PR DESCRIPTION
A private message in a chat for Coworkers (more like an internal note), should not be sent via WAHA. Therefor check if private is false